### PR TITLE
build: change build config for Node.js 16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@actions/core": "^1.6.0"
       },
       "devDependencies": {
+        "@tsconfig/node16-strictest": "^1.0.0",
         "@types/jest": "^27.4.1",
         "@typescript-eslint/eslint-plugin": "^5.13.0",
         "@typescript-eslint/parser": "^5.13.0",
@@ -30,7 +31,7 @@
         "typescript": "^4.6.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=16"
       }
     },
     "node_modules/@actions/core": {
@@ -1065,6 +1066,12 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16-strictest": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16-strictest/-/node16-strictest-1.0.0.tgz",
+      "integrity": "sha512-MTrFOCoWfjjhFpAoeHmWXFnYeRPxMBMgaNVszBYXJgPFi7XHYdRrDatgyk+Nb0ht7jWP3j/J3xXfvSXIjzRVKA==",
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.16",
@@ -6862,6 +6869,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
+    },
+    "@tsconfig/node16-strictest": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16-strictest/-/node16-strictest-1.0.0.tgz",
+      "integrity": "sha512-MTrFOCoWfjjhFpAoeHmWXFnYeRPxMBMgaNVszBYXJgPFi7XHYdRrDatgyk+Nb0ht7jWP3j/J3xXfvSXIjzRVKA==",
       "dev": true
     },
     "@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=12"
+    "node": ">=16"
   },
   "scripts": {
     "build": "ncc build src/main.ts -m --license licenses.txt",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@actions/core": "^1.6.0"
   },
   "devDependencies": {
+    "@tsconfig/node16-strictest": "^1.0.0",
     "@types/jest": "^27.4.1",
     "@typescript-eslint/eslint-plugin": "^5.13.0",
     "@typescript-eslint/parser": "^5.13.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node": ">=16"
   },
   "scripts": {
-    "build": "ncc build src/main.ts -m --license licenses.txt",
+    "build": "ncc build src/main.ts -m --target es2021 --license licenses.txt",
     "fix": "run-p \"lint:eslint --fix\" \"lint:prettier --write\"",
     "lint": "run-p lint:*",
     "lint:eslint": "eslint --ext .ts --ignore-path .gitignore .",

--- a/src/input.ts
+++ b/src/input.ts
@@ -23,5 +23,8 @@ export function getInputs(): Parameters<typeof chooseOne>[0] {
       `Parameters should be the same length. (contents: ${contents.length} weights: ${weights.length})`
     )
 
-  return contents.map((content, i) => ({ content, weight: weights[i] }))
+  return contents.map((content, i) => ({
+    content,
+    weight: weights[i] as number
+  }))
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,7 @@
 {
+  "extends": "@tsconfig/node16-strictest/tsconfig.json",
   "compilerOptions": {
-    "target": "es2018",
-    "lib": ["es2018"],
-    "moduleResolution": "node",
-    "rootDir": "./src",
-    "strict": true,
-    "noImplicitAny": true,
-    "esModuleInterop": true
+    "rootDir": "./src"
   },
   "exclude": ["node_modules", "__tests__", "jest.config.ts"],
   "types": ["jest"]


### PR DESCRIPTION
- Use `@tsconfig/node16-strictest`
- Bump `engines.node` verison to `>=16` in `package.json`
- Add `--target es2021` option on build 